### PR TITLE
Bug/gh issue 14

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@cds-au/testdata",
-  "version": "1.3.0",
+  "version": "1.4.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@cds-au/testdata",
-      "version": "1.3.0",
+      "version": "1.4.0",
       "license": "MIT",
       "dependencies": {
         "@types/consumer-data-standards": "7.1.0",

--- a/src/factories/energy/createEnergyTransactionsV2.ts
+++ b/src/factories/energy/createEnergyTransactionsV2.ts
@@ -49,7 +49,7 @@ Key values randomly allocated:
         
         let transaction : EnergyBillingTransactionV2 = {
             accountId: account.account.accountId,
-            executionDateTime: "",
+            executionDateTime:  Helper.randomDateTimeInThePast(),
             transactionUType: this.transactionUType
         }
 


### PR DESCRIPTION
- Generated random ISO datetime string for the effective date (closes #14)
- Fixed version error in package-lock.json (current published version is 1.4.0)